### PR TITLE
search task improvments

### DIFF
--- a/app/models/search_task.rb
+++ b/app/models/search_task.rb
@@ -16,9 +16,11 @@ class SearchTask < ApplicationRecord
   def process!
     begin
       update_column(:state, :processing)
-      parse_keywords_and_create_reports
-      update_column(:state, :complete)
-    rescue Exception => e
+      ActiveRecord::Base.transaction do
+        parse_keywords_and_create_reports
+        update_column(:state, :complete)
+      end
+    rescue StandardError => e
       update_column(:state, :failed)
       raise e
     end


### PR DESCRIPTION
for https://github.com/ankitkalia1195/searchbot/issues/8
Issues fixed - 
1) Using Standard Error instead of exception
2) Processing of all keywords in a transaction(did not do this earlier as I thought it might be good to keep results till the exception occurs)
3) kept update_column(:state, :processing) out of transaction so that it is updated instantly and user is able to view the state.

Not fixed -
1) Location of process! method(either we move all processing to job/service class which includes search_task, process_keywords, search report process) or we keep the method here.
2) Custom Errors I think are not required here, using the actual exception would be better and make it easier to debug.